### PR TITLE
Update renderer.js

### DIFF
--- a/app/renderer.js
+++ b/app/renderer.js
@@ -162,7 +162,7 @@ ipcRenderer.on('save-html', () => {
 });
 
 const markdownContextMenu = Menu.buildFromTemplate([
-  { label: 'Open File', click() { mainProcess.getFileFromUser(); } },
+  { label: 'Open File', click(item, focusedWindow) { mainProcess.getFileFromUser(focusedWindow); } },
   { type: 'separator' },
   { label: 'Cut', role: 'cut' },
   { label: 'Copy', role: 'copy' },


### PR DESCRIPTION
Add optional focusedWindow argument to click event in markdownContextMenu function.
It helps in to pass the same object to mainProcess when File Open dialogue gets triggered so that the dialogue gets displayed as a sheet from the focusedWindow.